### PR TITLE
Set dependency on Exlir 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "underscore": "^1.7.0",
     "gulp-requirejs": "^0.1.3"
   },
+  "peerDependencies": {
+    "laravel-elixir": "^2.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/joecohens/laravel-elixir-requirejs"


### PR DESCRIPTION
Related to issue #3
Though this pull request does not fix to problem it set the appropriate peer dependencies so that this package can not be installed when Exlir 3.0 is being used.
